### PR TITLE
fix: task value retrieval returned null under load

### DIFF
--- a/src/chicory/backend/redis.py
+++ b/src/chicory/backend/redis.py
@@ -82,14 +82,6 @@ class RedisBackend(Backend):
         if data:
             return TaskResult.model_validate_json(data)
 
-        # Check if we have just state
-        state: bytes | None = await self._client.get(self._state_key(task_id))
-        if state:
-            return TaskResult(
-                task_id=task_id,
-                state=TaskState(state.decode()),
-            )
-
         return None
 
     async def delete_result(self, task_id: str) -> None:

--- a/tests/unit/test_result.py
+++ b/tests/unit/test_result.py
@@ -47,6 +47,22 @@ class TestAsyncResultGet:
         assert result == 42
         assert backend_mock.get_result.call_count == 3
 
+    async def test_get_successful_result_without_value(self) -> None:
+        backend_mock = AsyncMock(spec=Backend)
+        # return a result after two polls
+        backend_mock.get_result = AsyncMock(
+            side_effect=[
+                None,
+                Mock(state=TaskState.PENDING, result=None, error=None),
+                Mock(state=TaskState.SUCCESS, result=None, error=None),
+            ]
+        )
+        async_result = AsyncResult[None](task_id="test-task", backend=backend_mock)
+
+        result = await async_result.get(timeout=1.0, poll_interval=0.01)
+        assert result is None
+        assert backend_mock.get_result.call_count == 3
+
     async def test_get_failure_result(self) -> None:
         backend_mock = AsyncMock(spec=Backend)
         backend_mock.get_result = AsyncMock(


### PR DESCRIPTION
Under load, we could end up in a situation where the task state would be created in Redis right after the check for the value existence. Also, it makes no sense to return the task's state in a method intended for returning the result.

Added an extra test for None values.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Streamlined task result retrieval to properly handle scenarios where tasks complete successfully without returning a value. Eliminated unnecessary fallback state lookups.

* **Tests**
  * Expanded test coverage for successful task completion when no return value is provided.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->